### PR TITLE
angular21: Verweis auf unveröffentlichten Vibe-Coding-Artikel entfernt

### DIFF
--- a/blog/2025-11-angular21/README.md
+++ b/blog/2025-11-angular21/README.md
@@ -250,8 +250,6 @@ The MCP server currently provides seven tools:
 6. Search the documentation (`search_documentation`).
 7. Perform code migrations with schematics (`modernize`, **experimental**).
 
-<!-- More details about `AGENTS.md`, MCP, and practical experience can be found in our detailed article about [Vibe Coding with Angular](/blog/2025-11-ai-mcp-vibe-coding). -->
-
 
 ## Migration scripts
 


### PR DESCRIPTION
Der auskommentierte Link zeigt auf `/blog/2025-11-ai-mcp-vibe-coding` — der Artikel wurde nie veröffentlicht, sein Inhalt ist im Claude-Code-Artikel aufgegangen.